### PR TITLE
[FEAT] Allow changing published name of calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ calendars:
 
   # basic example
   - name: example # used as slug in URL - e.g. ical-filter-proxy:8080/calendars/example/feed?token=changeme
+    publish_name: "My Calendar" # the published name of the calendar - uses upstream value if this line is skipped
     token: "changeme" # token used to pull iCal feed - authentication is disabled when blank
     feed_url: "https://my-upstream-calendar.url/feed.ics" # URL for the upstream iCal feed
     filters: # optional - if no filters defined the upstream calendar is proxied as parsed
@@ -105,6 +106,7 @@ calendars:
         
   # example: removing noise from an Office 365 calendar
   - name: outlook
+    publish_name: "My Outlook Calendar" # the published name of the calendar - uses upstream value if this line is skipped
     token: "changeme"
     feed_url: "https://outlook.office365.com/owa/calendar/.../reachcalendar.ics"
     filters:

--- a/calendar.go
+++ b/calendar.go
@@ -16,10 +16,11 @@ import (
 
 // CalendarConfig definition
 type CalendarConfig struct {
-	Name    string   `yaml:"name"`
-	Token   string   `yaml:"token"`
-	FeedURL string   `yaml:"feed_url"`
-	Filters []Filter `yaml:"filters"`
+	Name        string   `yaml:"name"`
+	PublishName string   `yaml:"publish_name"`
+	Token       string   `yaml:"token"`
+	FeedURL     string   `yaml:"feed_url"`
+	Filters     []Filter `yaml:"filters"`
 }
 
 // Downloads iCal feed from the URL and applies filtering rules
@@ -42,6 +43,10 @@ func (calendarConfig CalendarConfig) fetch() ([]byte, error) {
 	cal, err := ics.ParseCalendar(strings.NewReader(string(feedData)))
 	if err != nil {
 		return nil, err
+	}
+
+	if (calendarConfig.PublishName != "") {
+		cal.SetName(calendarConfig.PublishName)
 	}
 
 	// process filters


### PR DESCRIPTION
Allow using the `publish_name` yaml property at the `calendar` level to change the published name of each calendar.
Example:
```yaml
calendars:

  # basic example
  - name: example # used as slug in URL - e.g. ical-filter-proxy:8080/calendars/example/feed?token=changeme
    publish_name: "My Calendar" # the published name of the calendar
    token: "changeme" # token used to pull iCal feed - authentication is disabled when blank
    feed_url: "https://my-upstream-calendar.url/feed.ics" # URL for the upstream iCal feed
    filters: # optional - if no filters defined the upstream calendar is proxied as parsed
      - description: "Remove an event based on a regex"
        remove: true # events matching this filter will be removed
        match: # optional - all events will match if no rules defined
          summary: # match on event summary (title)
            contains: "deleteme" # must contain 'deleteme'
      - description: "Remove descriptions from all events"
        transform: # optional
          description: # modify event description
            remove: true # replace with a blank string
        
unsafe: false # optional - must be enabled if any calendars do not have a token
```